### PR TITLE
1.20.4 & new constantiam anti-cheat elytrafly restrictions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ yarn_mappings=1.20.4+build.3
 loader_version=0.15.7
 
 # Mod Properties
-mod_version=0.1.3
+mod_version=0.1.4
 maven_group=meteordevelopment.addons
 archives_base_name=meteor-constantiam
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties (https://fabricmc.net/versions.html)
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
-loader_version=0.14.23
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.7
 
 # Mod Properties
 mod_version=0.1.3
@@ -13,4 +13,4 @@ archives_base_name=meteor-constantiam
 # Dependencies
 
 # Meteor (https://maven.meteordev.org/)
-meteor_version=0.5.5-SNAPSHOT
+meteor_version=0.5.6-SNAPSHOT

--- a/src/main/java/maxsuperman/addon/meteorconstantiam/modules/AutoElytraSpeed.java
+++ b/src/main/java/maxsuperman/addon/meteorconstantiam/modules/AutoElytraSpeed.java
@@ -1,6 +1,5 @@
 package maxsuperman.addon.meteorconstantiam.modules;
 
-import meteordevelopment.meteorclient.events.packets.PacketEvent;
 import meteordevelopment.meteorclient.events.world.PlaySoundEvent;
 import meteordevelopment.meteorclient.events.world.TickEvent;
 import meteordevelopment.meteorclient.settings.*;
@@ -8,79 +7,52 @@ import meteordevelopment.meteorclient.systems.modules.Categories;
 import meteordevelopment.meteorclient.systems.modules.Module;
 import meteordevelopment.meteorclient.systems.modules.Modules;
 import meteordevelopment.meteorclient.systems.modules.movement.elytrafly.ElytraFly;
+import meteordevelopment.meteorclient.utils.world.TickRate;
 import meteordevelopment.orbit.EventHandler;
-import net.minecraft.network.packet.s2c.play.*;
 import net.minecraft.sound.SoundEvent;
 
 import java.util.List;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 public class AutoElytraSpeed extends Module {
     private final SettingGroup sgGeneral = settings.getDefaultGroup();
-    private final SettingGroup sgDetection = settings.createGroup("detection");
+    private final SettingGroup sgDetection = settings.createGroup("Detection");
 
     private final Setting<Double> defaultSpeed = sgGeneral.add(new DoubleSetting.Builder()
-        .name("default-speed")
+        .name("max-speed")
         .description("Speed without restrictions")
-        .defaultValue(2.2)
+        .defaultValue(2.3199)
+        .decimalPlaces(4)
         .build()
     );
 
-    private final Setting<Double> restrictedSpeed = sgGeneral.add(new DoubleSetting.Builder()
-        .name("restricted-speed")
-        .description("Speed with restrictions")
-        .defaultValue(1.4)
+    private final Setting<Double> speedMultiplier = sgGeneral.add(new DoubleSetting.Builder()
+        .name("speed-multiplier")
+        .description("Speed multiplier with restrictions")
+        .defaultValue(0.912)
+        .sliderRange(0.0, 1.0)
         .build()
     );
 
-    private final Setting<Integer> timeoutTicks = sgGeneral.add(new IntSetting.Builder()
-        .name("timeout-ticks")
-        .description("For how long to restrict speed")
-        .defaultValue(20)
+    private final Setting<Double> cutoffTps = sgGeneral.add(new DoubleSetting.Builder()
+        .name("cutoff-tps")
+        .description("Minimum TPS to restrict speed")
+        .defaultValue(8.0)
+        .sliderRange(0.0, 20.0)
         .build()
     );
 
-    public enum restrictionDetectMode {
-        HotbarMessage,
-        Sound
-    }
+    private final Setting<Integer> refreshRate = sgGeneral.add(new IntSetting.Builder()
+        .name("refresh-rate")
+        .description("How often should we set the speed, measured in ticks")
+        .defaultValue(50)
+        .sliderRange(10, 200)
+        .build()
+    );
 
     private final Setting<Boolean> onlyInFlight = sgDetection.add(new BoolSetting.Builder()
         .name("only-in-flight")
         .description("Triggers restriction only while flying")
-        .defaultValue(false)
-        .build()
-    );
-
-    public final Setting<AutoElytraSpeed.restrictionDetectMode> detectionMode = sgDetection.add(new EnumSetting.Builder<AutoElytraSpeed.restrictionDetectMode>()
-        .name("detection-mode")
-        .description("Depending on what to trigger restricted mode")
-        .defaultValue(AutoElytraSpeed.restrictionDetectMode.HotbarMessage)
-        .build()
-    );
-
-    private final Setting<String> matchingMessage = sgDetection.add(new StringSetting.Builder()
-        .name("message-filter")
-        .description("Regex for filtering speed limiter message")
-        .defaultValue("restricted")
-        .onChanged((String v) -> compileRegex())
-        .visible(() -> detectionMode.get() == restrictionDetectMode.HotbarMessage)
-        .build()
-    );
-
-    private final Setting<Boolean> suppressMessage = sgDetection.add(new BoolSetting.Builder()
-        .name("suppress-message")
-        .description("Cancels OverlayMessageS2CPacket if matched with filter")
-        .defaultValue(false)
-        .visible(() -> detectionMode.get() == restrictionDetectMode.HotbarMessage)
-        .build()
-    );
-
-    private final Setting<List<SoundEvent>> matchingSounds = sgDetection.add(new SoundEventListSetting.Builder()
-        .name("sounds-filter")
-        .description("Sounds to detect.")
-        .visible(() -> detectionMode.get() == restrictionDetectMode.Sound)
+        .defaultValue(true)
         .build()
     );
 
@@ -88,16 +60,12 @@ public class AutoElytraSpeed extends Module {
         .name("suppress-sound")
         .description("Cancels matching sounds")
         .defaultValue(false)
-        .visible(() -> detectionMode.get() == restrictionDetectMode.Sound)
         .build()
     );
 
-    private final Setting<Integer> soundDelay = sgDetection.add(new IntSetting.Builder()
-        .name("suppress-time")
-        .description("For how long to ignore sounds")
-        .defaultValue(20)
-        .visible(suppressSound::get)
-        .visible(() -> detectionMode.get() == restrictionDetectMode.Sound)
+    private final Setting<List<SoundEvent>> matchingSounds = sgDetection.add(new SoundEventListSetting.Builder()
+        .name("sounds-filter")
+        .description("Sounds to detect.")
         .build()
     );
 
@@ -105,18 +73,7 @@ public class AutoElytraSpeed extends Module {
         super(Categories.Movement, "auto-elytra-speed", "Automatically changes elytrafly speed");
     }
 
-    private Pattern triggerPattern = null;
-
-    public void compileRegex() {
-        try {
-            triggerPattern = Pattern.compile(matchingMessage.get());
-        } catch (PatternSyntaxException e) {
-            info(String.format("Pattern compile error: %s", e));
-        }
-    }
-
     private int timeoutLeft = 0;
-    private int soundBlock = 0;
 
     private void changeSpeed(double s) {
         Modules.get().get(ElytraFly.class).horizontalSpeed.set(s);
@@ -124,34 +81,18 @@ public class AutoElytraSpeed extends Module {
 
     @EventHandler
     private void onTick(TickEvent.Post event) {
-        if (soundBlock > 0) {
-            soundBlock--;
+        if (onlyInFlight.get() && !mc.player.isFallFlying()) {
+            return;
         }
-        if (timeoutLeft > 0) {
-            timeoutLeft--;
-            if (timeoutLeft == 0) {
-                changeSpeed(defaultSpeed.get());
+        timeoutLeft--;
+        if (timeoutLeft <= 0) {
+            float tps = TickRate.INSTANCE.getTickRate();
+            double speed = defaultSpeed.get();
+            if (tps >= cutoffTps.get()) {
+                speed *= tps / 20.0 * speedMultiplier.get();
             }
-        }
-    }
-
-    @EventHandler
-    private void onPacket(PacketEvent.Receive event) {
-        if (    detectionMode.get() == restrictionDetectMode.HotbarMessage &&
-                event.packet instanceof OverlayMessageS2CPacket &&
-                triggerPattern != null &&
-                triggerPattern.matcher(((OverlayMessageS2CPacket) event.packet).getMessage().getString()).find()) {
-            if (timeoutLeft > 0) {
-                info(String.format("Got speed limited while already with restricted speed (%d)", timeoutLeft));
-                toggle();
-            } else {
-                timeoutLeft = timeoutTicks.get();
-                changeSpeed(restrictedSpeed.get());
-                soundBlock = soundDelay.get();
-            }
-            if (suppressMessage.get()) {
-                event.cancel();
-            }
+            changeSpeed(speed);
+            timeoutLeft = refreshRate.get();
         }
     }
 
@@ -160,31 +101,15 @@ public class AutoElytraSpeed extends Module {
         if (mc.player == null) {
             return;
         }
-        if (detectionMode.get() == restrictionDetectMode.Sound) {
-            if (onlyInFlight.get()) {
-                if (!mc.player.isFallFlying()) {
-                    return;
-                }
-            }
-            for (SoundEvent sound : matchingSounds.get()) {
-                if (sound.getId().equals(event.sound.getId())) {
-                    timeoutLeft = timeoutTicks.get();
-                    changeSpeed(restrictedSpeed.get());
-                    if (suppressSound.get()) {
-                        event.cancel();
-                    }
-                    break;
-                }
-            }
-        } else {
-            if (soundBlock == 0) {
-                return;
-            }
-            for (SoundEvent sound : matchingSounds.get()) {
-                if (sound.getId().equals(event.sound.getId())) {
+        if (onlyInFlight.get() && !mc.player.isFallFlying()) {
+            return;
+        }
+        for (SoundEvent sound : matchingSounds.get()) {
+            if (sound.getId().equals(event.sound.getId())) {
+                if (suppressSound.get()) {
                     event.cancel();
-                    break;
                 }
+                break;
             }
         }
     }

--- a/src/main/java/maxsuperman/addon/meteorconstantiam/modules/TreeGrower.java
+++ b/src/main/java/maxsuperman/addon/meteorconstantiam/modules/TreeGrower.java
@@ -12,7 +12,6 @@ import meteordevelopment.meteorclient.utils.player.Rotations;
 import meteordevelopment.orbit.EventHandler;
 import net.minecraft.block.*;
 import net.minecraft.block.piston.PistonBehavior;
-import net.minecraft.block.sapling.*;
 import net.minecraft.item.Items;
 import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
 import net.minecraft.registry.tag.BlockTags;


### PR DESCRIPTION
Some major things I've noticed with the new Anti-Cheat config (since about late February?):

- The old/new chunks distinction seems gone by now, so I removed its detection
- The maximum elytrafly speed is now linearly related to the server tps so we have to sync it, but confusingly:
    - There seems to be 2 different types of restrictions:
        1. First one depends on the tps and is the one that constantly pings player back, but it does so even with ridiculously low efly speeds (maybe because of small lag spikes and mspt/network jitters) so our tps sync won't work perfectly - it'll just make the pings less often. I've made a speed multiplier of about 0.91 (configurable) to reduce this, so our speed would be
            * (*maxspeed* \* *multiplier* \* (*tps* / 20))
        2. Second one is the same as the old efly restriction and sets the absolute maximum speed (currently 46.4 bps or 2.3 in the config)
    - The first one is turned off completely if the server tps is below 8, so you can actually fly faster and smoother with low tps's.

Edit: slightly modified the format